### PR TITLE
ci: add advisory Arcade architecture analysis

### DIFF
--- a/.github/workflows/arcade-architecture-analysis.yml
+++ b/.github/workflows/arcade-architecture-analysis.yml
@@ -1,0 +1,28 @@
+name: Arcade Architecture Analysis
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  analyze:
+    name: Architecture advisory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lemduc/arcade-agent/actions/analyze@v0.1.1
+        with:
+          arcade-agent-version: "0.1.1"
+          language: java
+          primary-algorithm: pkg
+          run-secondary-analyses: "false"
+          upload-artifacts: "true"
+          post-pr-comment: "true"


### PR DESCRIPTION
## What changed

- add an advisory Arcade architecture analysis workflow for pull requests, `main` pushes, and manual runs
- pin both the composite action and installed package to released version `v0.1.1`
- analyze Java with the package-based recovery algorithm, upload the report, and store a default-branch baseline
- keep secondary analyses disabled to reduce CI time and update one idempotent PR summary when write access is available

## Why

This makes architectural drift visible alongside the existing build workflow without changing application behavior or introducing a merge threshold. Reviewers can inspect component and dependency changes as supporting evidence rather than treating a single score as a pass/fail gate.

The `issues: write` and `pull-requests: write` permissions are used only for the idempotent analysis comment. The action skips comments for forked pull requests, where GitHub does not grant a write token.

## Impact

This is CI-only and advisory. It does not modify the Java build, production code, or deployment flow.

## Validation

- `actionlint` passed for the workflow
- released `arcade-agent[languages]==0.1.1` completed a local Java/package baseline against `138c63e3b04d`
- baseline recovered 944 entities, 2,167 dependency edges, and 14 components

The detailed baseline interpretation is included in a separate PR comment.
